### PR TITLE
Sigwinsz pass upwards

### DIFF
--- a/slowtty.c
+++ b/slowtty.c
@@ -33,15 +33,10 @@
 #include "slowtty.h"
 #include "delay.h"
 
-#ifndef NDEBUG
-#define NDEBUG 0
-#endif
-
-int ptym, ptys;
-
 #define D(x) __FILE__":%d: %s: " x, __LINE__, __func__
 #define ERRNO ": %s (errno=%d)"
 #define EPMTS strerror(errno), errno
+/* XXX: fix with a portable parameter passing way */
 #define WARN(x, args...) do { \
         fprintf(stderr, D("WARNING: " x), args); \
     } while (0)
@@ -49,10 +44,6 @@ int ptym, ptys;
         fprintf(stderr, D("ERROR: " x ), args); \
         exit(EXIT_FAILURE); \
     } while (0)
-
-#if NDEBUG
-#define LOG(x, args...)
-#else
 #define LOG(x, args...) do { \
         if (flags & FLAG_VERBOSE) { \
             fprintf(stderr, \
@@ -60,12 +51,13 @@ int ptym, ptys;
                 args); \
         } \
     } while (0)
-#endif
 
+int ptym, ptys;
+/* to recover at the end and pass config to slave at beginning */
 struct termios saved_tty;
-struct winsize window_size;
+struct winsize saved_window_size;
 
-int flags = FLAG_DOWINCH;
+volatile int flags = FLAG_DOWINCH;
 
 struct pthread_info {
     pthread_t       id;
@@ -90,76 +82,96 @@ struct pthread_info *init_pthread_info(
     return pi;
 } /* init_pthread_info */
 
+void pass_data(struct pthread_info *pi)
+{
+    for (;;) {
+        int n;
+        unsigned char *p;
+        int res;
+        struct termios t;
+
+        /* the attributes of the line are got from the ptys
+         * always, as the user can change them at any time. */
+        tcgetattr(ptys, &t); /* to get speeds, etc */
+        n = delay(&t); /* do the delay. */
+        if (n) {
+            /* security net. Should never happen */
+            if (n > sizeof pi->buffer)
+                n = sizeof pi->buffer;
+            /* read the bytes indicated by the delay routine */
+            n = read(pi->from_fd, pi->buffer, n);
+            switch(n) {
+            case -1:
+                /* we can receive an interrupt from a SIGWINCH
+                 * signal, ignore it and reloop. */
+                if (errno != EINTR)
+                    ERR("read: " ERRNO "\r\n", EPMTS);
+                continue;
+            case 0:
+                /* should not happen, as terminals are in raw mode.
+                 */
+                LOG("EOF in %s thread\r\n", pi->name);
+                return;
+            default:
+                /* we did read something. try to write to the
+                 * other descriptor. */
+                p = pi->buffer;
+                while (n > 0) {
+                    res = write(pi->to_fd, p, n);
+                    if (res >= 0) {
+                        n -= res;
+                        p += res;
+                        continue;
+                    }
+                    /* res < 0 */
+                    if (errno != EINTR)
+                        ERR("write: " ERRNO "\r\n", EPMTS);
+                }
+            } /* switch */
+        } /* if */
+    } /* for */
+} /* pass_data */
+
 void *pthread_body_writer(void *_pi)
 {
     struct pthread_info *pi = _pi;
-    int flags;
-    struct termios t;
 
-
-    LOG("id=%p, from_fd=%d, to_fd=%d, name=%s, flags=%#08x\r\n",
-            pi->id, pi->from_fd, pi->to_fd, pi->name, flags);
-
-    for (;;) {
-        int n;
-
-        tcgetattr(pi->from_fd, &t);
-        n = delay(&t);
-        if (n) {
-            n = read(pi->from_fd, pi->buffer, n);
-            if (n <= 0) {
-                LOG("read" ERRNO "\r\n", EPMTS);
-                break;
-            } /* if */
-            n = write(pi->to_fd, pi->buffer, n);
-            if (n < 0) {
-                LOG("write" ERRNO "\r\n", EPMTS);
-                break;
-            } /* if */
-        } /* if */
-    } /* while */
-
+    LOG("id=%p, from_fd=%d, to_fd=%d, name=%s\r\n",
+            pi->id, pi->from_fd, pi->to_fd, pi->name);
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+    pass_data(pi);
     return NULL;
 } /* pthread_body_writer */
 
 void *pthread_body_reader(void *_pi)
 {
     struct pthread_info *pi = _pi;
-    ssize_t n;
-    int res;
-    struct winsize ws, ws_old;
 
     LOG("id=%p, from_fd=%d, to_fd=%d, name=%s\r\n",
             pi->id, pi->from_fd, pi->to_fd, pi->name);
-
     pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 
+    /* pass the tty config to the slave process at the beginning. */
     tcsetattr(pi->to_fd, TCSAFLUSH, &saved_tty);
-
-    while ((n = read(pi->from_fd,
-                     pi->buffer,
-                     sizeof pi->buffer)) > 0)
-    {
-        write(pi->to_fd, pi->buffer, n);
-    }
-
-    if (n < 0) LOG("read" ERRNO "\r\n", EPMTS);
-
+    pass_data(pi);
     return NULL;
 } /* pthread_body_reader */
 
 void pass_winsz(int sig)
 {
     struct winsize ws;
+    int res1, res2;
 
-    /* ioctl doesn't interact with any other part of
-     * the system, so we do both ioctl(2) calls
-     * asynchronously (as the ioctl is atomic). */
-
-    (ioctl(0, TIOCGWINSZ, &ws) >= 0) &&
-        (ioctl(1, TIOCGWINSZ, &ws) >= 0) &&
-        (ioctl(ptym, TIOCSWINSZ, &ws));
+    if ((flags & FLAG_DOWINCH)
+            && (ioctl(0, TIOCGWINSZ, &ws)
+                || ioctl(ptym, TIOCSWINSZ, &ws)))
+    {
+        WARN("cannot pass WINSZ from stdin to master pty: "
+                ERRNO ", disable it.\r\n", EPMTS);
+        flags &= ~FLAG_DOWINCH; /* disable */
+    }
 } /* pass_winsz */
 
 int main(int argc, char **argv)
@@ -190,24 +202,35 @@ int main(int argc, char **argv)
 
     /* get the window size */
     if (flags & FLAG_DOWINCH) {
-        int res = ioctl(0, TIOCGWINSZ, &window_size);
+        int res = ioctl(0, TIOCGWINSZ, &saved_window_size);
         if (res < 0) {
             WARN("winsize:" ERRNO ", disabling\n", EPMTS);
             flags &= ~FLAG_DOWINCH;
         }
     }
 
-    /* XXX: We need to change the forkpty by its internals as we
-     * need to access the ptyslave descriptor in the parent process,
-     * and unfortunately, forkpty(3) doesn't expose it.  It is
-     * needed in the parent process to pass up the window change
-     * condition. */
-    child_pid = forkpty(&ptym, pty_name, &saved_tty, &window_size);
+    res = openpty(&ptym, &ptys, pty_name, &saved_tty, &saved_window_size);
+    LOG("openpty => %d\n", res);
+    if (res < 0) {
+        ERR("openpty: " ERRNO "\n", EPMTS);
+    }
+
+    child_pid = fork();
 
     switch(child_pid) {
-    case -1: ERR("fork" ERRNO, EPMTS);
+    case -1:
+        ERR("fork" ERRNO "\n", EPMTS);
+        break; /* unneeded, but don't hurt */
+
     case 0: { /* child process */
             int res;
+
+            res = login_tty(ptys);
+            if (res < 0) {
+                ERR("logintty:%s: " ERRNO "\n", pty_name, EPMTS);
+            }
+
+            close(ptym); close(ptys);
 
             if (argc) {
                 execvp(argv[0], argv);
@@ -223,30 +246,35 @@ int main(int argc, char **argv)
                     shell = u->pw_shell;
                 } /* if */
             
+                LOG("execlp: %s\n", shell);
                 execlp(shell, shell, NULL);
                 ERR("execlp: %s" ERRNO "\r\n", shell, EPMTS);
             } /* if */
             /* NOTREACHED */
         } /* case */
+
     default: { /* parent process */
             struct pthread_info p_in, p_out;
             int res, exit_code = 0;
             struct sigaction sa;
             struct termios stty_raw = saved_tty;
 
-	    LOG("forkpty: child_pid == %d\n", child_pid);
+            LOG("fork: child_pid == %d, ptym=%d, ptys=%d, "
+                    "pty_name=[%s]\n",
+                    child_pid, ptym, ptys, pty_name);
 
             cfmakeraw(&stty_raw);
             res = tcsetattr(0, TCSAFLUSH, &stty_raw);
             if (res < 0) {
-                ERR("tcsetattr(ptym, ...): ERROR" ERRNO "\n", EPMTS);
+                ERR("tcsetattr(ptym, ...): " ERRNO "\n", EPMTS);
             } /* if */
 
-            memset(&sa, 0, sizeof sa);
-            sa.sa_handler = pass_winsz;
-
-            /* install signal handler */
-            sigaction(SIGWINCH, &sa, NULL);
+            if (flags & FLAG_DOWINCH) {
+                LOG("installing signal handler\n", NULL);
+                memset(&sa, 0, sizeof sa);
+                sa.sa_handler = pass_winsz;
+                sigaction(SIGWINCH, &sa, NULL);
+            }
 
             /* create the subthreads to process info */
             res = pthread_create(
@@ -257,8 +285,9 @@ int main(int argc, char **argv)
                         0, ptym,
                         "READ",
                         &p_in));
+            LOG("pthread_create: id=%p, res=%d\r\n", p_in.id, res);
             if (res < 0)
-                ERR("pthread_create" ERRNO "\r\n", EPMTS);
+                ERR("pthread_create: " ERRNO "\r\n", EPMTS);
 
             res = pthread_create(
                     &p_out.id,
@@ -269,37 +298,39 @@ int main(int argc, char **argv)
                         "WRITE",
                         &p_out));
             LOG("pthread_create: id=%p, res=%d\r\n", p_in.id, res);
-            if (res < 0) ERR("pthread_create" ERRNO "\r\n", EPMTS);
+            if (res < 0) ERR("pthread_create: " ERRNO "\r\n", EPMTS);
 
             /* wait for subprocess to terminate */
-            res = wait(&exit_code);
-            LOG("wait(&exit_code => %d) => %d\r\n", exit_code, res);
+            wait(&exit_code);
+            LOG("wait(&exit_code <= %d);\r\n", exit_code);
 
             /* join writing thread */
+            LOG("pthread_join(%p, NULL);...\r\n", p_out.id);
             if ((res = pthread_join(p_out.id, NULL)) < 0)
                 ERR("pthread_join" ERRNO "\r\n", EPMTS);
-            LOG("pthread_join(%p, NULL) => %d\r\n", p_out.id, res);
+            LOG("pthread_join(%p, NULL); => %d\r\n", p_out.id, res);
 
             /* cancel reading thread */
             res = pthread_cancel(p_in.id);
-            LOG("pthread_cancel(%p) => %d\r\n", p_in.id, res);
+            LOG("pthread_cancel(%p); => %d\r\n", p_in.id, res);
 
             /* join it */
+            LOG("pthread_join(%p, NULL);...\r\n", p_in.id);
             res = pthread_join(p_in.id, NULL);
-            LOG("pthread_join(%p, NULL) => %d\r\n", p_in.id, res);
+            LOG("pthread_join(%p, NULL); => %d\r\n", p_in.id, res);
 
             /* restore the settings from the saved ones. We
              * follow the same procedure (first with stdin, then
              * with stdout) so we configure the same settings
              * to the same channel as in the beginning. */
             res = tcsetattr(0, TCSAFLUSH, &saved_tty);
-	    LOG("tcsetattr(0, TCSAFLUSH, &saved_tty) => %d\n", res);
+            LOG("tcsetattr(0, TCSAFLUSH, &saved_tty) => %d\n", res);
             if (res < 0) {
-                LOG("tcsetattr(0, ...): ERROR" ERRNO "\r\n", EPMTS);
+                LOG("tcsetattr(0, ...): ERROR" ERRNO "\n", EPMTS);
             } /* if */
 
             /* exit with the subprocess exit code */
-            LOG("exit(%d)\n", WEXITSTATUS(exit_code));
+            LOG("exit(%d);\n", WEXITSTATUS(exit_code));
             exit(WEXITSTATUS(exit_code));
         } /* case */
     } /* switch */

--- a/slowtty.c
+++ b/slowtty.c
@@ -1,7 +1,16 @@
-/* slowtty.c -- program to slow down the output of characters to be able to follow
- * output as if a slow terminal were attached to the computer.
+/* slowtty.c -- program to slow down the output of characters to be able
+ * to follow output as if a slow terminal were attached to the computer.
  * Author: Luis Colorado <luiscoloradourcola@gmail.com>
- * Copyright: (C) 2015 LUIS COLORADO.  This is open source copyrighted software.
+ * Date: Wed Aug  3 08:12:26 EEST 2016
+ * Copyright: (C) 2015 LUIS COLORADO.
+ * This is open source copyrighted software according to the BSD license.
+ * You can copy and distribute freely this piece of software, in source
+ * or binary form, agreeing in that you are not going to eliminate the
+ * above copyright notice and author from the source code or binary
+ * announcements the program could make.
+ * The software is distributed 'AS IS' which means that the author doesn't
+ * accept any liabilities or responsibilities derived of the use the final
+ * user or derived works could make of it.
  */
 
 #include <assert.h>
@@ -188,6 +197,11 @@ int main(int argc, char **argv)
         }
     }
 
+    /* XXX: We need to change the forkpty by its internals as we
+     * need to access the ptyslave descriptor in the parent process,
+     * and unfortunately, forkpty(3) doesn't expose it.  It is
+     * needed in the parent process to pass up the window change
+     * condition. */
     child_pid = forkpty(&ptym, pty_name, &saved_tty, &window_size);
 
     switch(child_pid) {

--- a/slowtty.c
+++ b/slowtty.c
@@ -38,17 +38,17 @@
 #define EPMTS strerror(errno), errno
 /* XXX: fix with a portable parameter passing way */
 #define WARN(x, args...) do { \
-        fprintf(stderr, D("WARNING: " x), args); \
+        fprintf(stderr, D("WARNING: " x), ##args); \
     } while (0)
 #define ERR(x, args...) do { \
-        fprintf(stderr, D("ERROR: " x ), args); \
+        fprintf(stderr, D("ERROR: " x ), ##args); \
         exit(EXIT_FAILURE); \
     } while (0)
 #define LOG(x, args...) do { \
         if (flags & FLAG_VERBOSE) { \
             fprintf(stderr, \
                 D("INFO: " x), \
-                args); \
+                ##args); \
         } \
     } while (0)
 
@@ -192,7 +192,7 @@ int main(int argc, char **argv)
     argc -= optind; argv += optind;
 
     if (!isatty(0)) {
-        ERR("stdin is not a tty, aborting\n", NULL);
+        ERR("stdin is not a tty, aborting\n");
     }
 
     /* we obtain the tty settings from stdin . */
@@ -242,7 +242,7 @@ int main(int argc, char **argv)
                 if (!shell) {
                     struct passwd *u = getpwnam(getlogin());
                     if (!u)
-                        ERR("getpwnam failed\r\n", NULL);
+                        ERR("getpwnam failed\r\n");
                     shell = u->pw_shell;
                 } /* if */
             
@@ -270,7 +270,7 @@ int main(int argc, char **argv)
             } /* if */
 
             if (flags & FLAG_DOWINCH) {
-                LOG("installing signal handler\n", NULL);
+                LOG("installing signal handler\n");
                 memset(&sa, 0, sizeof sa);
                 sa.sa_handler = pass_winsz;
                 sigaction(SIGWINCH, &sa, NULL);
@@ -298,7 +298,8 @@ int main(int argc, char **argv)
                         "WRITE",
                         &p_out));
             LOG("pthread_create: id=%p, res=%d\r\n", p_in.id, res);
-            if (res < 0) ERR("pthread_create: " ERRNO "\r\n", EPMTS);
+            if (res < 0)
+                ERR("pthread_create: " ERRNO "\r\n", EPMTS);
 
             /* wait for subprocess to terminate */
             wait(&exit_code);

--- a/slowtty.h
+++ b/slowtty.h
@@ -10,6 +10,6 @@
 #define FLAG_VERBOSE    (1 << 0)
 #define FLAG_DOWINCH    (1 << 1)
 #define FLAG_NOTCSET    (1 << 2)
-extern int flags;
+extern volatile int flags;
 
 #endif /* _SLOWTTY_H */


### PR DESCRIPTION
`SIGWINSZ` passes upwards to the slave pty, and threads are synchronized with data flow, so they finish orderly when input has drained.
